### PR TITLE
fix: chash test case

### DIFF
--- a/t/chash.t
+++ b/t/chash.t
@@ -41,7 +41,6 @@ __DATA__
             local res = {}
             for i = 1, 100 * 1000 do
                 local id = chash:find(i)
-
                 if res[id] then
                     res[id] = res[id] + 1
                 else
@@ -49,8 +48,9 @@ __DATA__
                 end
             end
 
-            for id, num in pairs(res) do
-                ngx.say(id, ": ", num)
+            for i=1, 3 do
+                local id = "server"..i
+                ngx.say(id..": ", res[id])
             end
 
             ngx.say("points number: ", chash.npoints)
@@ -59,8 +59,8 @@ __DATA__
 --- request
 GET /t
 --- response_body
-server2: 14743
 server1: 77075
+server2: 14743
 server3: 8182
 points number: 2080
 --- no_error_log


### PR DESCRIPTION
table `servers` do not guarantee the order, so the test case may get failed in some conditions.
```
local servers = {
       ["server1"] = 10,
       ["server2"] = 2,
       ["server3"] = 1,
}

```

```
➜  lua-resty-balancer git:(hotfix/testcase) ✗ make test
PATH=/usr/local/openresty-debug/nginx/sbin:$PATH prove -I../test-nginx/lib -r t
t/chash.t ....... 13/30 

#   Failed test 'TEST 1: find - response_body - response is expected (repeated req 0, req 0)'
#   at /usr/local/share/perl/5.30.0/Test/Nginx/Socket.pm line 1589.
# @@ -1,4 +1,4 @@
# +server3: 8182
#  server1: 77075
#  server2: 14743
# -server3: 8182
#  points number: 2080

#   Failed test 'TEST 1: find - response_body - response is expected (repeated req 1, req 0)'
#   at /usr/local/share/perl/5.30.0/Test/Nginx/Socket.pm line 1589.
# @@ -1,4 +1,4 @@
# +server3: 8182
#  server1: 77075
#  server2: 14743
# -server3: 8182
#  points number: 2080
# Looks like you failed 2 tests of 30.
```