### PR TITLE
Make explicitly type conversion on _gcd() parameter to prevent infinite loop

### DIFF
--- a/lib/resty/roundrobin.lua
+++ b/lib/resty/roundrobin.lua
@@ -17,7 +17,8 @@ local mt = { __index = _M }
 
 local _gcd
 _gcd = function (a, b)
-    if b == 0 then
+    b = tonumber(b)
+    if b == 0 or b == nil then
         return a
     end
 


### PR DESCRIPTION
#### Reference Issues
The current implementation may cause _gcd() into an infinite loop if the parameter b is a unexpected value like string '0'. Which caused the video platform Bilibili its massive outage on 2021/7/13.

Reference: https://mp.weixin.qq.com/s/zCOnUEp25xYqx7BMyrLIGQ

#### The change
To prevent the condition makes the infinite loop, we have to make an explicit type conversion so that the `b == 0` condition can be met when there's any undesired value.